### PR TITLE
Add Google Analytics integration to layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,6 +35,24 @@ export default function RootLayout({
             `,
           }}
         />
+
+        {/* Google Analytics (gtag.js) */}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-F17ZE6HR64"
+          strategy="afterInteractive"
+        />
+        <Script
+          id="gtag-init"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-F17ZE6HR64');
+            `,
+          }}
+        />
       </head>
       <body className="antialiased min-h-screen flex flex-col">
         {/* Google Tag Manager (noscript) */}


### PR DESCRIPTION
Included Google Analytics (gtag.js) scripts in the RootLayout component to enable tracking. Scripts are loaded after interactive for performance.