### PR TITLE
Extract character video logic into util

### DIFF
--- a/src/app/character/[ocid]/character-details-client.tsx
+++ b/src/app/character/[ocid]/character-details-client.tsx
@@ -6,31 +6,12 @@ import { characterDataService } from "@/services/character-data.service";
 import { CharacterData } from "@/types/maplestory-api";
 import Header from "@/components/Header";
 import { buildUrl } from "@/config/routes";
+import { getCharacterVideoSrc } from "@/utils/character-video";
 import { EquipmentTab } from "./components/EquipmentTab";
 import { HyperTab } from "./components/HyperTab";
 import { SymbolsTab } from "./components/SymbolsTab";
 import { LinkSkillsTab } from "./components/LinkSkillsTab";
 import { GrowthTab } from "./components/GrowthTab";
-
-const getCharacterDetailVideoSrc = (characterClass?: string) => {
-  if (!characterClass) {
-    return null;
-  }
-
-  const specialFileNames: Record<string, string> = {
-    "Arch Mage (Fire/Poison)": "arch mage fire poison.mp4",
-    "Arch Mage (F/P)": "arch mage fire poison.mp4",
-    "Arch Mage (Ice/Lightning)": "arch mage ice lightning.mp4",
-    "Arch Mage (I/L)": "arch mage ice lightning.mp4",
-    Hoyoung: "hoyung.mp4",
-    Illium: "ilium.mp4",
-  };
-
-  const fileName =
-    specialFileNames[characterClass] ?? `${characterClass.toLowerCase()}.mp4`;
-
-  return `/images/characters/video/${encodeURIComponent(fileName)}`;
-};
 
 interface CharacterDetailsClientProps {
   ocid: string;
@@ -906,7 +887,7 @@ export function CharacterDetailsClient({
                               ))}
                           </div>
 
-                          {getCharacterDetailVideoSrc(
+                          {getCharacterVideoSrc(
                             characterData.basic?.character_class,
                           ) && (
                             <div className="flex justify-center lg:justify-end">
@@ -930,7 +911,7 @@ export function CharacterDetailsClient({
                                 >
                                   <source
                                     src={
-                                      getCharacterDetailVideoSrc(
+                                      getCharacterVideoSrc(
                                         characterData.basic?.character_class,
                                       ) ?? undefined
                                     }

--- a/src/app/maplecharacters/page.tsx
+++ b/src/app/maplecharacters/page.tsx
@@ -9,6 +9,7 @@ import {
   type MapleCharacterEntry,
   type MapleCharacterCategory,
 } from "@/data/maple-characters";
+import { getCharacterVideoSrc } from "@/utils/character-video";
 
 const categoryStyles: Record<
   MapleCharacterCategory,
@@ -65,18 +66,6 @@ const getCharacterImageSrc = (name: string) => {
 
   const fileName = specialFileNames[name] ?? `${name.toLowerCase()}.png`;
   return `/images/characters/${encodeURIComponent(fileName)}`;
-};
-
-const getCharacterVideoSrc = (name: string) => {
-  const specialFileNames: Record<string, string> = {
-    "Arch Mage (Fire/Poison)": "arch mage fire poison.mp4",
-    "Arch Mage (Ice/Lightning)": "arch mage ice lightning.mp4",
-    Hoyoung: "hoyung.mp4",
-    Illium: "ilium.mp4",
-  };
-
-  const fileName = specialFileNames[name] ?? `${name.toLowerCase()}.mp4`;
-  return `/images/characters/video/${encodeURIComponent(fileName)}`;
 };
 
 const statTicks = [20, 40, 60, 80, 100] as const;
@@ -393,7 +382,7 @@ export default function MaplecharactersPage() {
                     poster={getCharacterImageSrc(selectedCharacter.name)}
                   >
                     <source
-                      src={getCharacterVideoSrc(selectedCharacter.name)}
+                      src={getCharacterVideoSrc(selectedCharacter.name) ?? undefined}
                       type="video/mp4"
                     />
                   </video>

--- a/src/utils/character-video.ts
+++ b/src/utils/character-video.ts
@@ -1,0 +1,100 @@
+const CHARACTER_VIDEO_FILES = [
+  "adele.mp4",
+  "angelic buster.mp4",
+  "aran.mp4",
+  "arch mage fire poison.mp4",
+  "arch mage ice lightning.mp4",
+  "ark.mp4",
+  "battle mage.mp4",
+  "bishop.mp4",
+  "blaster.mp4",
+  "blaze wizard.mp4",
+  "bow master.mp4",
+  "buccaneer.mp4",
+  "cadena.mp4",
+  "cannoneer.mp4",
+  "corsair.mp4",
+  "dark knight.mp4",
+  "dawn warrior.mp4",
+  "demon avenger.mp4",
+  "demon slayer.mp4",
+  "dual blade.mp4",
+  "evan.mp4",
+  "hayato.mp4",
+  "hero.mp4",
+  "hoyung.mp4",
+  "ilium.mp4",
+  "kain.mp4",
+  "kaiser.mp4",
+  "kanna.mp4",
+  "khali.mp4",
+  "kinesis.mp4",
+  "lara.mp4",
+  "luminous.mp4",
+  "lynn.mp4",
+  "marksman.mp4",
+  "mechanic.mp4",
+  "mercedes.mp4",
+  "mihile.mp4",
+  "mo xuan.mp4",
+  "night lord.mp4",
+  "night walker.mp4",
+  "paladin.mp4",
+  "pathfinder.mp4",
+  "phantom.mp4",
+  "ren.mp4",
+  "shade.mp4",
+  "shadower.mp4",
+  "sia astelle.mp4",
+  "thunder breaker.mp4",
+  "wild hunter.mp4",
+  "wind archer.mp4",
+  "xenon.mp4",
+  "zero.mp4",
+] as const;
+
+const normalizeMediaKey = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/\.mp4$/i, "")
+    .replace(/[^a-z0-9]/g, "");
+
+const normalizedVideoFileMap = new Map<string, string>(
+  CHARACTER_VIDEO_FILES.map((fileName) => [normalizeMediaKey(fileName), fileName]),
+);
+
+const normalizedAliases = new Map<string, string>([
+  [normalizeMediaKey("Arch Mage (F/P)"), "arch mage fire poison.mp4"],
+  [normalizeMediaKey("Arch Mage (I/L)"), "arch mage ice lightning.mp4"],
+  [normalizeMediaKey("Soul Master"), "dawn warrior.mp4"],
+  [normalizeMediaKey("Hoyoung"), "hoyung.mp4"],
+  [normalizeMediaKey("Illium"), "ilium.mp4"],
+]);
+
+export const resolveCharacterVideoFileName = (
+  characterClassOrName?: string,
+): string | null => {
+  if (!characterClassOrName) {
+    return null;
+  }
+
+  const normalizedInput = normalizeMediaKey(characterClassOrName);
+  const aliasedFile = normalizedAliases.get(normalizedInput);
+
+  if (aliasedFile) {
+    return aliasedFile;
+  }
+
+  return normalizedVideoFileMap.get(normalizedInput) ?? null;
+};
+
+export const getCharacterVideoSrc = (
+  characterClassOrName?: string,
+): string | null => {
+  const fileName = resolveCharacterVideoFileName(characterClassOrName);
+  if (!fileName) {
+    return null;
+  }
+
+  return `/images/characters/video/${encodeURIComponent(fileName)}`;
+};


### PR DESCRIPTION
Add src/utils/character-video.ts to centralize character video filename resolution (file list, normalization, alias map) and export resolveCharacterVideoFileName and getCharacterVideoSrc. Replace duplicated inline video lookup functions in CharacterDetailsClient and MaplecharactersPage to import and use the new util, and update video source usage to handle missing values. This deduplicates logic, adds normalization/alias support, and makes future updates to video mappings easier.